### PR TITLE
Added defaultRedactionConfig in the text scanning method

### DIFF
--- a/src/types/scanText.ts
+++ b/src/types/scanText.ts
@@ -5,6 +5,7 @@ export namespace ScanText {
     detectionRuleUUIDs?: string[]
     detectionRules?: Detector.Rule[]
     contextBytes?: number
+    defaultRedactionConfig?: Detector.RedactionConfig
   }
 
   export interface Response {


### PR DESCRIPTION
Adds support to optionally include a default redaction config in the text scanning method.