### PR TITLE
Add support for AlertConfig

### DIFF
--- a/src/types/alerts.ts
+++ b/src/types/alerts.ts
@@ -1,19 +1,19 @@
 export namespace Alerts {
-  export interface AlertConfig {
-    slack?: SlackAlert;
-    email?: EmailAlert;
-    url?: WebhookAlert;
+  export interface Config {
+    slack?: Slack;
+    email?: Email;
+    url?: Webhook;
   }
 
-  export interface SlackAlert {
+  export interface Slack {
     target: string;
   }
 
-  export interface EmailAlert {
+  export interface Email {
     address: string;
   }
 
-  export interface WebhookAlert {
+  export interface Webhook {
     address: string;
   }
 }

--- a/src/types/alerts.ts
+++ b/src/types/alerts.ts
@@ -1,0 +1,19 @@
+export namespace Alerts {
+  export interface AlertConfig {
+    slack?: SlackAlert;
+    email?: EmailAlert;
+    url?: WebhookAlert;
+  }
+
+  export interface SlackAlert {
+    target: string;
+  }
+
+  export interface EmailAlert {
+    address: string;
+  }
+
+  export interface WebhookAlert {
+    address: string;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,4 @@
+export * from './alerts'
 export * from './detectors'
 export * from './global'
 export * from './scanFile'

--- a/src/types/scanFile.ts
+++ b/src/types/scanFile.ts
@@ -1,4 +1,4 @@
-import { Detector, NightfallError } from ".";
+import { Alerts, Detector, NightfallError } from ".";
 
 export namespace ScanFile {
   export interface ScanRequest {
@@ -10,6 +10,7 @@ export namespace ScanFile {
     detectionRuleUUIDs?: string[]
     detectionRules?: Detector.Rule[]
     webhookURL: string
+    alertConfig?: Alerts.AlertConfig
   }
 
   export interface InitializeResponse {

--- a/src/types/scanFile.ts
+++ b/src/types/scanFile.ts
@@ -9,8 +9,8 @@ export namespace ScanFile {
   export interface ScanPolicy {
     detectionRuleUUIDs?: string[]
     detectionRules?: Detector.Rule[]
-    webhookURL: string
-    alertConfig?: Alerts.AlertConfig
+    webhookURL?: string // Deprecated, use alertConfig instead
+    alertConfig?: Alerts.Config
   }
 
   export interface InitializeResponse {

--- a/src/types/scanText.ts
+++ b/src/types/scanText.ts
@@ -6,7 +6,7 @@ export namespace ScanText {
     detectionRules?: Detector.Rule[]
     contextBytes?: number
     defaultRedactionConfig?: Detector.RedactionConfig
-    alertConfig?: Alerts.AlertConfig
+    alertConfig?: Alerts.Config
   }
 
   export interface Response {

--- a/src/types/scanText.ts
+++ b/src/types/scanText.ts
@@ -1,4 +1,4 @@
-import { Detector } from ".";
+import { Alerts, Detector } from ".";
 
 export namespace ScanText {
   export interface RequestConfig {
@@ -6,6 +6,7 @@ export namespace ScanText {
     detectionRules?: Detector.Rule[]
     contextBytes?: number
     defaultRedactionConfig?: Detector.RedactionConfig
+    alertConfig?: Alerts.AlertConfig
   }
 
   export interface Response {


### PR DESCRIPTION
Callers may provide an alertConfig object as part of either a synchronous plaintext scan, or an asynchronous file scan to fan alerts out to any of { slack, email, and webhook}.